### PR TITLE
Update GitHub Actions and drop the decommissioned OSSRH repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -14,7 +14,7 @@ jobs:
       packages: read
       security-events: write
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -57,7 +57,7 @@ jobs:
         # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
     steps:
     - name: Checkout repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`
@@ -67,7 +67,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -96,6 +96,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
+      uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Checkout the PR branch
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM maven:3.9.16-eclipse-temurin-21 as build
+FROM maven:3.9.16-eclipse-temurin-21 AS build
 COPY src /home/app/src
 COPY pom.xml /home/app
 COPY settings.xml /root/.m2/settings.xml

--- a/settings.xml
+++ b/settings.xml
@@ -3,22 +3,6 @@
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
 
-    <activeProfiles>
-        <activeProfile>github</activeProfile>
-    </activeProfiles>
-
-    <profiles>
-        <profile>
-            <id>github</id>
-            <repositories>
-                <repository>
-                    <id>ossrh-releases</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/releases</url>
-                </repository>
-            </repositories>
-        </profile>
-    </profiles>
-
     <servers>
         <server>
             <id>github</id>


### PR DESCRIPTION
## Summary

This repository turned out to need far less than the other two in this sweep. The parent is already current and the module pins nothing that has moved, so the changes here are confined to a dead Maven repository, two action pins, and a Dockerfile lint fix.

## Parent and dependencies: no change needed

- The parent is **already** on `com.otilm:dependencies:1.4.2-SNAPSHOT`. Nothing to bump.
- The module declares **no CVE override properties**, so there is no redundant or downgraded pin to clean up.
- `com.otilm:interfaces` is at `2.18.1-SNAPSHOT`, the current `main` version.
- `net.steppschuh.markdowngenerator` is at 1.3.1.1, the latest release.

`versions:display-dependency-updates` reports outdated artifacts, but every one of them is managed by the parent or by Spring Boot rather than pinned in this POM, so none can be acted on from here:

| Dependency | Current | Available | Managed by |
|---|---|---|---|
| `spring-boot-starter-*` | 3.5.16 | 4.1.0 | Parent's Spring Boot version — major, org-wide decision |
| `spring-security-core` | 6.5.11 | 7.1.0 | Arrives with Spring Boot 4 |
| `flyway-core`, `flyway-database-postgresql` | 11.7.2 | 13.1.0 | Spring Boot managed — major |
| `commons-lang3` | 3.17.0 | 3.20.0 | Spring Boot managed |
| `hsqldb` | 2.7.3 | 2.7.4 | Spring Boot managed |
| `postgresql` | 42.7.12 | 42.7.13 | Parent override |
| `bcprov-jdk18on`, `bcpkix-jdk18on` | 1.84 | 1.85 | Parent pin |

The last two rows are actionable, but in `OmniTrustILM/dependencies`, not here. See the follow-ups below.

## Dropped the decommissioned OSSRH repository

`settings.xml` is installed by the Dockerfile as the build stage's `/root/.m2/settings.xml`, and it declared `s01.oss.sonatype.org` as an active repository. Sonatype retired that host; it now answers with a redirect or 403 instead of serving artifacts, so every image build consulted a dead host during dependency resolution.

This is not hypothetical. The same stale file in `scheduler` produced a non-deterministic image build there — one architecture failed to resolve `spring-boot-starter-parent` through the dead host while the other resolved it from Maven Central on the same commit (OmniTrustILM/scheduler#109).

Removal is safe: releases come from Maven Central via the Maven super-POM, and the `com.otilm` SNAPSHOTs come from the `central-portal` repository already declared in `pom.xml`, which serves them without authentication.

## GitHub Actions

| Action | Previous | Updated to |
|---|---|---|
| `actions/checkout` | `9c091b…e3e0 # v7.0.0` | `3d3c42…90b1 # v7.0.1` |
| `github/codeql-action` | `7188fc…f97a # v4.37.1` | `f205ea…7b38 # v4.37.4` |

Already current: `actions/setup-java` v5.6.0, `actions/cache` v6.1.0, `actions/upload-artifact` v7.0.1, `actions/download-artifact` v8.0.1, `octokit/request-action` v3.0.0. The `OmniTrustILM/.github` reusable workflows stay on `@main` by convention.

## Container

Capitalised `as` → `AS` in the build stage to silence BuildKit's `FromAsCasing` warning.

Deliberately left alone:

- The runtime stage already runs `apk update && apk upgrade --no-cache`, so the libexpat and p11-kit advisories that needed fixing in the other two repos are already handled here.
- The runtime base stays pinned at `eclipse-temurin:21.0.11_10-jre-alpine`. That tag was rebuilt on 2026-06-22, the same day as the floating `21-jre-alpine`, so it is not stale, and the explicit pin is the more reproducible choice.
- The build stage is already on `maven:3.9.16-eclipse-temurin-21`.

## Follow-ups for the parent

Both belong in `OmniTrustILM/dependencies`, where the versions are actually set:

- `postgresql` 42.7.12 → 42.7.13. The parent overrides this ahead of Spring Boot 3.5.16's managed 42.7.11 for CVE-2026-54291, and the override has now fallen a patch behind upstream.
- `bouncycastle` 1.84 → 1.85.

## Superseded

Bot PRs to close once this merges: #50, #57.

#58 (`Sync repo to org template`) also touches the workflow files; expect a conflict depending on merge order.