### PR TITLE
Sanitize template-failure logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Email Notification Provider `Connector` is provided as a Docker container. Use t
 | `SMTP_PASSWORD` | SMTP password                                            | ![](https://img.shields.io/badge/-NO-red.svg)      | `N/A`         |
 | `SMTP_AUTH`     | SMTP authentication                                      | ![](https://img.shields.io/badge/-NO-red.svg)      | `true`        |
 | `SMTP_TLS`      | SMTP TLS                                                 | ![](https://img.shields.io/badge/-NO-red.svg)      | `true`        |
+| `NOTIFICATION_LOG_REQUEST_PAYLOAD` | Include the notification request in DEBUG logs. See [How to enable DEBUG logs](#how-to-enable-debug-logs) | ![](https://img.shields.io/badge/-NO-red.svg) | `false` |
 
 ## Attributes to configure
 
@@ -139,6 +140,17 @@ To enable DEBUG logs for the implementation of the email notification provider, 
 ```shell
 LOGGING_LEVEL_COM_OTILM=DEBUG
 ```
+
+DEBUG logs describe each notification by its identifiers only — event, resource, recipient count, and whether notification data is present. The notification request itself is never written to the logs at any level unless payload logging is switched on explicitly:
+
+```shell
+NOTIFICATION_LOG_REQUEST_PAYLOAD=true
+```
+
+> **Warning**
+> With payload logging enabled, DEBUG logs contain the complete notification request, including data that can be sensitive — for example the one-time credential of certificate registration events, or object data enabled on the notification profile. Enable it only while troubleshooting, and treat the logs accordingly.
+
+Template failures do not need it: they are reported at ERROR level with the template identifier, the event and resource, and the position of the failing expression in the template, without exposing any payload.
 
 To enable DEBUG logs for the mail sending process and SMTP related information, you need to set the following environment variable:
 ```shell

--- a/src/main/java/com/otilm/np/email/service/impl/NotificationInstanceServiceImpl.java
+++ b/src/main/java/com/otilm/np/email/service/impl/NotificationInstanceServiceImpl.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -48,6 +49,14 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
 
     private AttributeService attributeService;
 
+    /**
+     * Whether DEBUG logging includes the notification request itself. The request carries values
+     * that must not reach logs by default — the certificate-registration credential among them —
+     * so payload logging is a separate, deliberate switch rather than a side effect of raising the
+     * log level.
+     */
+    private boolean logRequestPayload;
+
     @Autowired
     public void setNotificationInstanceRepository(NotificationInstanceRepository notificationInstanceRepository) {
         this.notificationInstanceRepository = notificationInstanceRepository;
@@ -56,6 +65,11 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
     @Autowired
     public void setEmailSender(JavaMailSender emailSender) {
         this.emailSender = emailSender;
+    }
+
+    @Value("${notification.log-request-payload:false}")
+    public void setLogRequestPayload(boolean logRequestPayload) {
+        this.logRequestPayload = logRequestPayload;
     }
 
     @Autowired
@@ -150,7 +164,11 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
                 .findByUuid(uuid)
                 .orElseThrow(() -> new NotFoundException(NotificationInstance.class, uuid));
 
-        logger.debug("Request to send email received with the content: {}", request);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Request to send email received: {}", logRequestPayload
+                    ? TemplateUtils.describeRequestForDebug(request)
+                    : TemplateUtils.summarizeRequest(request));
+        }
 
         MimeMessage mimeMessage = emailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, "utf-8");
@@ -158,8 +176,8 @@ public class NotificationInstanceServiceImpl implements NotificationInstanceServ
         String htmlMsg = notificationInstance.getContentTemplate();
         String Subject = notificationInstance.getSubject();
 
-        final String substitutedHtmlMsg = TemplateUtils.processFreeMarkerTemplate(htmlMsg, request);
-        final String substitutedSubject = TemplateUtils.processFreeMarkerTemplate(Subject, request);
+        final String substitutedHtmlMsg = TemplateUtils.processFreeMarkerTemplate("email content", htmlMsg, request);
+        final String substitutedSubject = TemplateUtils.processFreeMarkerTemplate("email subject", Subject, request);
 
         logger.debug("Resolving recipients from request input: {}", request.getRecipients());
         final String[] recipients = getRecipients(request.getRecipients());

--- a/src/main/java/com/otilm/np/email/util/TemplateUtils.java
+++ b/src/main/java/com/otilm/np/email/util/TemplateUtils.java
@@ -2,8 +2,10 @@ package com.otilm.np.email.util;
 
 import com.otilm.api.model.connector.notification.NotificationProviderNotifyRequestDto;
 import com.otilm.np.email.exception.NotificationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import freemarker.template.TemplateException;
@@ -20,15 +22,67 @@ public class TemplateUtils {
 
     private static final Logger logger = LoggerFactory.getLogger(TemplateUtils.class);
 
-    public static String processFreeMarkerTemplate(String data, NotificationProviderNotifyRequestDto request) {
+    /**
+     * Shared mapper: constructing one per call is expensive, and the registered modules keep
+     * types such as {@code java.time} serializable instead of degrading DEBUG output to the
+     * unserializable placeholder.
+     */
+    private static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder().findAndAddModules().build();
+
+    private TemplateUtils() {
+    }
+
+    /**
+     * Payload-free summary of a notification request: identifiers and counts only. This is what
+     * DEBUG logging reports unless payload logging is explicitly switched on.
+     */
+    public static String summarizeRequest(NotificationProviderNotifyRequestDto request) {
+        return "event=%s, resource=%s, recipients=%d, notificationData=%s".formatted(
+                request.getEvent(), request.getResource(),
+                request.getRecipients() == null ? 0 : request.getRecipients().size(),
+                request.getNotificationData() == null ? "absent" : "present");
+    }
+
+    /**
+     * Serializes the whole notification request for opt-in DEBUG logging — the sanctioned way
+     * to inspect payload content when debugging. Uses explicit JSON serialization because the
+     * request's {@code toString} deliberately excludes the payload-bearing fields, which would
+     * make DEBUG output silently incomplete. A request that cannot be serialized — including one
+     * whose own accessors fail — yields a payload-free placeholder rather than disrupting the
+     * send flow.
+     */
+    public static String describeRequestForDebug(NotificationProviderNotifyRequestDto request) {
+        try {
+            return OBJECT_MAPPER.writeValueAsString(request);
+        } catch (JsonProcessingException | RuntimeException e) {
+            return "unserializable notification request (" + e.getClass().getSimpleName() + ")";
+        }
+    }
+
+    /**
+     * Renders the given FreeMarker template against the notification request.
+     *
+     * <p>Failure logs and exception messages carry the template label, the event and resource
+     * identifiers, and the underlying error only — never the request payload or the data model.
+     * The request's {@code notificationData} and {@code objectData} can hold sensitive values
+     * (for example a certificate-registration credential), and the thrown exception's message
+     * becomes this connector's HTTP error response toward the platform, so payload content must
+     * not reach either. Full request visibility for debugging remains available through the
+     * DEBUG-level logging of the send flow.</p>
+     *
+     * @param templateLabel identifies the rendered template in errors, e.g. "email subject"
+     */
+    public static String processFreeMarkerTemplate(String templateLabel, String templateSource, NotificationProviderNotifyRequestDto request) {
         // Convert request to a Map instead of using the JSON node directly
-        ObjectMapper objectMapper = new ObjectMapper();
         Map<String, Object> dataModel;
         try {
-            dataModel = objectMapper.convertValue(request, new TypeReference<>() {});
+            dataModel = OBJECT_MAPPER.convertValue(request, new TypeReference<>() {});
         } catch (IllegalArgumentException e) {
-            logger.error("Error while converting request to Map: {}, {}", request, e.getMessage());
-            throw new NotificationException("Error while converting request to Map: " + request + ", " + e.getMessage());
+            // Only the exception type is reported: Jackson conversion messages can embed model
+            // paths or content, and this internal failure has no template-author diagnostics value.
+            logger.error("Failed to build the {} template data model: event={}, resource={}, error={}",
+                    templateLabel, request.getEvent(), request.getResource(), e.getClass().getSimpleName());
+            throw new NotificationException("Failed to build the " + templateLabel + " template data model (" + e.getClass().getSimpleName() + ")");
         }
 
         // Prepare FreeMarker configuration
@@ -41,10 +95,13 @@ public class TemplateUtils {
         // Create template from the HTML string
         Template template;
         try {
-            template = new Template("contentTemplate", new StringReader(data), cfg);
+            template = new Template(templateLabel, new StringReader(templateSource), cfg);
         } catch (IOException e) {
-            logger.error("Error while creating FreeMarker template: {}, {}", data, e.getMessage());
-            throw new NotificationException("Error while creating FreeMarker template: " + e.getMessage(), e);
+            // Parsing happens before the data model is bound, so this message describes the
+            // operator's own template only and cannot quote payload values.
+            logger.error("Failed to parse the {} template: event={}, resource={}, error={}",
+                    templateLabel, request.getEvent(), request.getResource(), e.getMessage());
+            throw new NotificationException("Failed to parse the " + templateLabel + " template: " + e.getMessage(), e);
         }
 
         // Process the template with the data model
@@ -52,11 +109,27 @@ public class TemplateUtils {
         try {
             template.process(dataModel, stringWriter);
         } catch (TemplateException | IOException e) {
-            logger.error("Error while processing FreeMarker template: {}, {}", request, e.getMessage());
-            throw new NotificationException("Error while processing FreeMarker template: " + e.getMessage());
+            String diagnostics = renderFailureDiagnostics(e);
+            logger.error("Failed to render the {} template: event={}, resource={}, error={}",
+                    templateLabel, request.getEvent(), request.getResource(), diagnostics);
+            throw new NotificationException("Failed to render the " + templateLabel + " template: " + diagnostics);
         }
 
         return stringWriter.toString();
+    }
+
+    /**
+     * Payload-free description of a rendering failure. FreeMarker quotes the value that failed to
+     * evaluate in its message — {@code ${credential?number}} embeds the credential verbatim — so
+     * only the exception type and the position in the template are reported. The template is the
+     * operator's own content, so the position identifies the failing expression for them.
+     */
+    static String renderFailureDiagnostics(Exception e) {
+        if (e instanceof TemplateException templateException) {
+            return "%s at line %s, column %s".formatted(e.getClass().getSimpleName(),
+                    templateException.getLineNumber(), templateException.getColumnNumber());
+        }
+        return e.getClass().getSimpleName();
     }
 
 }

--- a/src/test/java/com/otilm/np/email/service/impl/NotificationInstanceServiceImplTest.java
+++ b/src/test/java/com/otilm/np/email/service/impl/NotificationInstanceServiceImplTest.java
@@ -24,6 +24,10 @@ import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.np.email.dao.entity.NotificationInstance;
 import com.otilm.np.email.dao.repository.NotificationInstanceRepository;
 import com.otilm.np.email.service.AttributeService;
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import jakarta.mail.internet.MimeMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,11 +35,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 import org.springframework.mail.javamail.JavaMailSender;
 
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -541,6 +547,86 @@ class NotificationInstanceServiceImplTest {
         attributes.add(template);
         request.setAttributes(attributes);
         return request;
+    }
+
+    /**
+     * Payload logging is opt-in: raising the log level alone must never write the request into the
+     * logs, only the payload-free summary.
+     */
+    @Test
+    void sendNotification_debugLoggingWithoutOptIn_logsNoPayload() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        NotificationInstance instance = buildPersistedInstance(uuid);
+        when(repository.findByUuid(uuid)).thenReturn(Optional.of(instance));
+
+        MimeMessage mimeMessage = new MimeMessage((jakarta.mail.Session) null);
+        when(emailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        NotificationRecipientDto recipient = new NotificationRecipientDto();
+        recipient.setName("R1");
+        recipient.setEmail("to@example.com");
+        NotificationProviderNotifyRequestDto request = buildNotifyRequest(List.of(recipient));
+        request.setNotificationData(Map.of("credential", "must-not-be-logged"));
+
+        Logger serviceLogger = (Logger) LoggerFactory.getLogger(NotificationInstanceServiceImpl.class);
+        Level originalLevel = serviceLogger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+        serviceLogger.setLevel(Level.DEBUG);
+        try {
+            service.sendNotification(uuid, request);
+        } finally {
+            serviceLogger.setLevel(originalLevel);
+            serviceLogger.detachAppender(appender);
+            appender.stop();
+        }
+
+        List<String> messages = appender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
+        assertTrue(messages.stream().noneMatch(message -> message.contains("must-not-be-logged")),
+                "DEBUG alone must not write the request payload: " + messages);
+        assertTrue(messages.stream().anyMatch(message -> message.contains("recipients=1")),
+                "the payload-free summary must still be logged: " + messages);
+    }
+
+    /**
+     * With payload logging switched on, the full request is available for troubleshooting.
+     */
+    @Test
+    void sendNotification_debugLoggingRetainsRequestVisibility() throws Exception {
+        UUID uuid = UUID.randomUUID();
+        NotificationInstance instance = buildPersistedInstance(uuid);
+        when(repository.findByUuid(uuid)).thenReturn(Optional.of(instance));
+
+        MimeMessage mimeMessage = new MimeMessage((jakarta.mail.Session) null);
+        when(emailSender.createMimeMessage()).thenReturn(mimeMessage);
+
+        NotificationRecipientDto recipient = new NotificationRecipientDto();
+        recipient.setName("R1");
+        recipient.setEmail("to@example.com");
+        NotificationProviderNotifyRequestDto request = buildNotifyRequest(List.of(recipient));
+        request.setNotificationData(Map.of("credential", "debug-visible-credential"));
+
+        service.setLogRequestPayload(true);
+
+        Logger serviceLogger = (Logger) LoggerFactory.getLogger(NotificationInstanceServiceImpl.class);
+        Level originalLevel = serviceLogger.getLevel();
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        serviceLogger.addAppender(appender);
+        serviceLogger.setLevel(Level.DEBUG);
+        try {
+            service.sendNotification(uuid, request);
+        } finally {
+            serviceLogger.setLevel(originalLevel);
+            serviceLogger.detachAppender(appender);
+            appender.stop();
+        }
+
+        assertTrue(appender.list.stream()
+                        .map(ILoggingEvent::getFormattedMessage)
+                        .anyMatch(message -> message.contains("debug-visible-credential")),
+                "with payload logging enabled the request content must be available");
     }
 
     private NotificationProviderNotifyRequestDto buildNotifyRequest(List<NotificationRecipientDto> recipients) {

--- a/src/test/java/com/otilm/np/email/util/CertActionPerformedTemplateUtilsTest.java
+++ b/src/test/java/com/otilm/np/email/util/CertActionPerformedTemplateUtilsTest.java
@@ -37,7 +37,7 @@ public class CertActionPerformedTemplateUtilsTest extends BaseSpringBootTest {
 
     @Test
     public void testTemplateUtils() {
-        String processedHtmlTemplate = TemplateUtils.processFreeMarkerTemplate(HTML_TEMPLATE, request);
+        String processedHtmlTemplate = TemplateUtils.processFreeMarkerTemplate("email content", HTML_TEMPLATE, request);
 
         Assertions.assertTrue(processedHtmlTemplate.contains("Subject: " + SUBJECT_DN));
         Assertions.assertTrue(processedHtmlTemplate.contains("Serial Number: " + SERIAL_NUMBER));

--- a/src/test/java/com/otilm/np/email/util/CertStatusChangedTemplateUtilsTest.java
+++ b/src/test/java/com/otilm/np/email/util/CertStatusChangedTemplateUtilsTest.java
@@ -38,7 +38,7 @@ Certificate "${notificationData.subjectDn}" status changed to <#if notificationD
 
     @Test
     public void testTemplateUtils() {
-        String processedHtmlTemplate = TemplateUtils.processFreeMarkerTemplate(HTML_TEMPLATE, request);
+        String processedHtmlTemplate = TemplateUtils.processFreeMarkerTemplate("email content", HTML_TEMPLATE, request);
 
         Assertions.assertTrue(processedHtmlTemplate.contains("Subject: " + SUBJECT_DN));
         Assertions.assertTrue(processedHtmlTemplate.contains("Serial Number: " + SERIAL_NUMBER));
@@ -48,7 +48,7 @@ Certificate "${notificationData.subjectDn}" status changed to <#if notificationD
 
     @Test
     public void testTemplateUtilsSubject() {
-        String processedSubject = TemplateUtils.processFreeMarkerTemplate(SUBJECT, request);
+        String processedSubject = TemplateUtils.processFreeMarkerTemplate("email subject", SUBJECT, request);
 
         Assertions.assertTrue(processedSubject.contains("Certificate \"" + SUBJECT_DN + "\" status changed to " + NEW_STATUS));
     }

--- a/src/test/java/com/otilm/np/email/util/TemplateUtilsErrorTest.java
+++ b/src/test/java/com/otilm/np/email/util/TemplateUtilsErrorTest.java
@@ -1,32 +1,192 @@
 package com.otilm.np.email.util;
 
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.otilm.api.model.connector.notification.NotificationProviderNotifyRequestDto;
+import com.otilm.api.model.core.auth.Resource;
+import com.otilm.api.model.core.other.ResourceEvent;
 import com.otilm.np.email.exception.NotificationException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
 
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class TemplateUtilsErrorTest {
 
+    private static final String TEMPLATE_LABEL = "email content";
+    private static final String SENSITIVE_VALUE = "registration-credential-7f3a9";
+
+    private ListAppender<ILoggingEvent> logAppender;
+
+    @BeforeEach
+    void captureLogs() {
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        ((Logger) LoggerFactory.getLogger(TemplateUtils.class)).addAppender(logAppender);
+    }
+
+    @AfterEach
+    void releaseLogs() {
+        ((Logger) LoggerFactory.getLogger(TemplateUtils.class)).detachAppender(logAppender);
+        logAppender.stop();
+    }
+
     private NotificationProviderNotifyRequestDto request() {
-        return new NotificationProviderNotifyRequestDto();
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        request.setEvent(ResourceEvent.CERTIFICATE_REGISTERED);
+        request.setResource(Resource.CERTIFICATE);
+        request.setNotificationData(Map.of("credential", SENSITIVE_VALUE));
+        return request;
     }
 
     @Test
     void malformedTemplateThrowsCreationError() {
-        NotificationProviderNotifyRequestDto request = request();
         NotificationException ex = assertThrows(NotificationException.class,
-                () -> TemplateUtils.processFreeMarkerTemplate("${unclosed", request));
-        assertTrue(ex.getMessage().contains("creating FreeMarker template"));
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "${unclosed", request()));
+        assertTrue(ex.getMessage().contains(TEMPLATE_LABEL));
+        assertNoPayloadExposure(ex);
     }
 
     @Test
     void unresolvedReferenceThrowsProcessingError() {
-        NotificationProviderNotifyRequestDto request = request();
         NotificationException ex = assertThrows(NotificationException.class,
-                () -> TemplateUtils.processFreeMarkerTemplate("${totallyMissingVar}", request));
-        assertTrue(ex.getMessage().contains("processing FreeMarker template"));
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "${totallyMissingVar}", request()));
+        assertTrue(ex.getMessage().contains(TEMPLATE_LABEL));
+        assertTrue(ex.getMessage().contains("line"), "the rendering failure must stay locatable in the template");
+        assertNoPayloadExposure(ex);
+    }
+
+    @Test
+    void renderingFailureLogsTemplateAndEventIdentifiers() {
+        NotificationProviderNotifyRequestDto request = request();
+        assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "${totallyMissingVar}", request));
+
+        List<String> errorLogs = formattedLogs();
+        assertFalse(errorLogs.isEmpty());
+        assertTrue(errorLogs.stream().anyMatch(message -> message.contains(TEMPLATE_LABEL)
+                        && message.contains(String.valueOf(request.getEvent()))
+                        && message.contains(String.valueOf(request.getResource()))),
+                "failure log must identify the template, event, and resource: " + errorLogs);
+    }
+
+    @Test
+    void dataModelConversionFailureExposesNoPayload() {
+        NotificationProviderNotifyRequestDto request = request();
+        request.setNotificationData(new Object() {
+            public String getCredential() {
+                return SENSITIVE_VALUE;
+            }
+
+            public String getBoom() {
+                // The cause message lands inside Jackson's conversion-failure message, so it must
+                // not be forwarded either — only the exception type may be reported.
+                throw new IllegalStateException("boom-" + SENSITIVE_VALUE);
+            }
+        });
+
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL, "irrelevant", request));
+        assertTrue(ex.getMessage().contains(TEMPLATE_LABEL));
+        assertNoPayloadExposure(ex);
+    }
+
+    /**
+     * FreeMarker quotes the offending value in coercion failures, so the raw message must never
+     * reach the log or the exception returned to the platform.
+     */
+    @Test
+    void coercionFailureExposesNoPayloadValue() {
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL,
+                        "${notificationData.credential?number}", request()));
+
+        assertNoPayloadExposure(ex);
+        assertTrue(ex.getMessage().contains("line"), "the failure must still point at the template position");
+    }
+
+    /** Date coercion quotes the value in its own message format, so it is covered separately. */
+    @Test
+    void dateCoercionFailureExposesNoPayloadValue() {
+        NotificationException ex = assertThrows(NotificationException.class,
+                () -> TemplateUtils.processFreeMarkerTemplate(TEMPLATE_LABEL,
+                        "${notificationData.credential?datetime}", request()));
+
+        assertNoPayloadExposure(ex);
+    }
+
+    /** Failures without a template position fall back to the exception type alone. */
+    @Test
+    void nonTemplateRenderFailureIsDescribedByTypeOnly() {
+        assertTrue(TemplateUtils.renderFailureDiagnostics(new java.io.IOException("writer broke on " + SENSITIVE_VALUE))
+                .equals("IOException"));
+    }
+
+    @Test
+    void summaryReportsIdentifiersWithoutPayload() {
+        String summary = TemplateUtils.summarizeRequest(request());
+
+        assertFalse(summary.contains(SENSITIVE_VALUE), "the summary must never carry payload values");
+        assertTrue(summary.contains("notificationData=present"));
+        assertTrue(summary.contains("recipients=0"));
+    }
+
+    /** Recipient-less profiles send no recipients and events may carry no data; neither must fail. */
+    @Test
+    void summaryHandlesAbsentRecipientsAndData() {
+        NotificationProviderNotifyRequestDto request = new NotificationProviderNotifyRequestDto();
+        request.setEvent(ResourceEvent.CERTIFICATE_STATUS_CHANGED);
+        request.setResource(Resource.CERTIFICATE);
+
+        String summary = TemplateUtils.summarizeRequest(request);
+
+        assertTrue(summary.contains("recipients=0"));
+        assertTrue(summary.contains("notificationData=absent"));
+    }
+
+    @Test
+    void debugDescriptionCarriesFullPayload() {
+        assertTrue(TemplateUtils.describeRequestForDebug(request()).contains(SENSITIVE_VALUE),
+                "DEBUG description is the sanctioned payload-visibility mechanism and must serialize the payload");
+    }
+
+    @Test
+    void debugDescriptionOfUnserializableRequestIsPayloadFree() {
+        NotificationProviderNotifyRequestDto request = request();
+        request.setNotificationData(new Object() {
+            public String getCredential() {
+                return SENSITIVE_VALUE;
+            }
+
+            public String getBoom() {
+                throw new IllegalStateException("boom");
+            }
+        });
+
+        String description = TemplateUtils.describeRequestForDebug(request);
+        assertTrue(description.contains("unserializable"));
+        assertFalse(description.contains(SENSITIVE_VALUE));
+    }
+
+    private void assertNoPayloadExposure(NotificationException ex) {
+        assertFalse(ex.getMessage().contains(SENSITIVE_VALUE),
+                "exception message must not carry the request payload: " + ex.getMessage());
+        for (String message : formattedLogs()) {
+            assertFalse(message.contains(SENSITIVE_VALUE),
+                    "log output must not carry the request payload: " + message);
+        }
+    }
+
+    private List<String> formattedLogs() {
+        return logAppender.list.stream().map(ILoggingEvent::getFormattedMessage).toList();
     }
 
 }


### PR DESCRIPTION
Closes #56

Template-rendering failures logged the entire notification request at ERROR level and embedded it into the exception message returned to the platform, where it also reached the platform's logs. The request can carry sensitive values — for example the one-time credential of certificate registration events, or object data enabled on the notification profile.

- Failure logs and exception messages now carry only the template label (`email subject` / `email content`), the event and resource identifiers, and the rendering error; data-model conversion failures report only the exception type.
- DEBUG-level request logging is deliberately retained as the opt-in way to inspect the payload while debugging, now serialized explicitly so payload fields stay visible regardless of the DTO's `toString` behavior. The README warns about its sensitivity.
- Regression tests assert that failure logs and exception messages carry no payload fields on any failure path, and that DEBUG logging keeps the request visible.